### PR TITLE
chore: bump version for next release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
             Check linting with Clippy and rustfmt, build the crate, and run tests.
         executor:
             name: rust/default
-            tag: 1.71.1
+            tag: 1.81.0
         environment:
             RUSTFLAGS: '-D warnings'
         steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "eth_trie"
-version = "0.4.0"
-authors = ["Jason Carver <ut96caarrs@snkmail.com>"]
+version = "0.5.0"
+authors = ["https://github.com/ethereum/eth-trie.rs/graphs/contributors"]
 description = "Ethereum-compatible Merkle-Patricia Trie."
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 keywords = ["patricia", "mpt", "evm", "trie", "ethereum"]
-repository = "https://github.com/carver/eth-trie.rs"
-homepage = "https://github.com/carver/eth-trie.rs"
+repository = "https://github.com/ethereum/eth-trie.rs"
+homepage = "https://github.com/ethereum/eth-trie.rs"
 documentation = "https://docs.rs/eth_trie"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.5.0"
 authors = ["https://github.com/ethereum/eth-trie.rs/graphs/contributors"]
 description = "Ethereum-compatible Merkle-Patricia Trie."
 license = "Apache-2.0"
+rust-version = "1.81.0"
 edition = "2021"
 readme = "README.md"
 keywords = ["patricia", "mpt", "evm", "trie", "ethereum"]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ## eth-trie
 
 [![Latest Version](https://img.shields.io/crates/v/eth_trie.svg)](https://crates.io/crates/eth_trie)
-[![](https://img.shields.io/hexpm/l/plug.svg)](https://github.com/carver/eth-trie.rs/blob/master/LICENSE)
-[![CircleCI](https://circleci.com/gh/carver/eth-trie.rs/tree/master.svg?style=svg)](https://circleci.com/gh/carver/eth-trie.rs/tree/master)
+[![](https://img.shields.io/hexpm/l/plug.svg)](https://github.com/ethereum/eth-trie.rs/blob/master/LICENSE)
+[![CircleCI](https://circleci.com/gh/ethereum/eth-trie.rs/tree/master.svg?style=svg)](https://circleci.com/gh/ethereum/eth-trie.rs/tree/master)
 
 Rust implementation of the Merkle-Patricia Trie, used by Ethereum.
 
@@ -105,4 +105,4 @@ See: https://crates.io/crates/hasher
 
 ### Custom storage
 
-[Refer](https://github.com/carver/eth-trie.rs/blob/master/src/db.rs)
+[Refer](https://github.com/ethereum/eth-trie.rs/blob/master/src/db.rs)


### PR DESCRIPTION
In this PR I
- bump the version
- update metadata including link to authors and repo link to be consistent with how we do things in the `trin` repo
- update rust version in CI

after this PR is merged we can cut a github release then a crates.io release

