### PR TITLE
Remove some unnecessary db lookups from node removal

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
             Check linting with Clippy and rustfmt, build the crate, and run tests.
         executor:
             name: rust/default
-            tag: 1.81.0
+            tag: 1.87.0
         environment:
             RUSTFLAGS: '-D warnings'
         steps:


### PR DESCRIPTION
The recursive nature of `degenerate`, which is called as part of removing nodes from the trie, led to it unnecessarily fetching the children of extension nodes in certain circumstances.

We encountered this as an issue when we were trying to do removals from an incomplete trie. We had all the nodes necessary to do the removal, but sometimes would get missing node errors as a result of this over-eager fetching.

In this PR I've reworked the `delete_at` and `degenerate` methods a bit to avoid these unnecessary db queries. I also included a unit test that captures this behavior. The test fails when run with the current released code due to a missing node error on the `remove` call.

ETA: There's still a few edge cases that can cause nodes to be fetched unnecessarily. This should be good to merge as-is, but I might update with more fixes if I can work them out.

ETA2: I've pushed a commit with another fix