### PR TITLE
chore: bump version to 0.6.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "eth_trie"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["https://github.com/ethereum/eth-trie.rs/graphs/contributors"]
 description = "Ethereum-compatible Merkle-Patricia Trie."
 license = "Apache-2.0"
-rust-version = "1.81.0"
+rust-version = "1.87.0"
 edition = "2021"
 readme = "README.md"
 keywords = ["patricia", "mpt", "evm", "trie", "ethereum"]


### PR DESCRIPTION
Bumping the version for the next release.